### PR TITLE
Add support to bootstrap with sh / without bash

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,19 +45,18 @@ Clone the repo and run one command install:
 
 Script `bootstrap` runs all the scripts documented below.
 
-It passes `-f` to the scripts to not prompt anything.
-
 ### ⚙️ Dotfiles
 
-Symlinks all the `dotfiles` to user's home directory (`-f` to skip prompts):
+Symlinks all files in `dotfiles/` to home directory (pass `-f` to skip prompts):
 
     ./symlink_dotfiles
 
-Directory `bin` is symlinked to `~/local/bin` which takes preference in `PATH`,
-thus binaries in it are available by name.
+Directory `bin` is symlinked to `~/local/bin` which takes preference in `PATH`.
 
-Restart the shell to load the shell configs (and `.profile` setting the `PATH`),
-or run `source ~/.zshrc` (or `source ~/.bashrc`).
+If an existing `~/local/bin` exists, it is first backed up as `~/local/bin-old`.
+
+Restart the shell, or run `source ~/.zshrc` (or `source ~/.bashrc`) and
+binaries in `bin/` are available by name.
 
 ### 🖥️ Apps
 
@@ -82,7 +81,7 @@ Finally `pyenv`, `rbenv` and `nvm` and defined language versions are installed.
 
 ### 🖊️ Visual Studio Code
 
-Symlink the `vscode/` directory (`-f` to replace `code/User` without prompting):
+Symlink `vscode/` to `<vscode_config_path>/Code` (back ups old as `Code-old`):
 
     ./setup_vscode
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Things are happening per user, but `sudo` may be required for some OS features.
 
 ## TL;DR
 
-    curl -sS https://raw.githubusercontent.com/raas-dev/configent/main/install.sh | bash
+    curl -fsSL https://raw.githubusercontent.com/raas-dev/configent/main/install.sh | bash
 
 If git is not present, it is installed by APT or YUM (or by Xcode command line
 tools on macOS) and the repo is cloned to `$HOME/configent`.

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Principles:
 
 Features:
 
-- Bootstrap macOS/APT/YUM Linux distros one command only with `curl` and `bash`
+- Bootstrap macOS/APT/YUM Linux distros one command only, only `curl` required
 - One character shell aliases - the fastest are the commands one does not write
 - In terminal, Rust and Go written utilities are always preferred due to speed
 - Best practices language multiple versioning with `pyenv`, `rbenv` and `nvm`
@@ -22,7 +22,7 @@ Things are happening per user, but `sudo` may be required for some OS features.
 
 ## TL;DR
 
-    curl -fsSL https://raw.githubusercontent.com/raas-dev/configent/main/install.sh | bash
+    curl -fsSL https://raw.githubusercontent.com/raas-dev/configent/main/install.sh | sh
 
 If git is not present, it is installed by APT or YUM (or by Xcode command line
 tools on macOS) and the repo is cloned to `$HOME/configent`.

--- a/bin/docker-compose
+++ b/bin/docker-compose
@@ -13,7 +13,7 @@ install_docker_compose_plugin() {
     echo "Downloading docker-compose as Docker CLI plugin on $os ($arch)"
     rm -f "$HOME/.docker/cli-plugins/docker-compose"
     mkdir -p "$HOME/.docker/cli-plugins/"
-    curl -L "https://github.com/docker/compose/releases/latest/download/docker-compose-$os-$arch" \
+    curl -fsSL "https://github.com/docker/compose/releases/latest/download/docker-compose-$os-$arch" \
       -o "$HOME/.docker/cli-plugins/docker-compose"
     chmod +x "$HOME/.docker/cli-plugins/docker-compose"
   fi

--- a/bin/install_apps_apt
+++ b/bin/install_apps_apt
@@ -1,12 +1,12 @@
-#!/bin/bash
+#!/bin/sh
 
-trap "echo -e '\nCaught ^C from user - exiting now' ; exit 130" SIGINT
+trap "echo -e '\nCaught ^C from user - exiting now' ; exit 130" INT
 
-if [ "$EUID" = "0" ]; then
+if [ "$(id -u)" = 0 ]; then
     SUDO=''
     SUDOEULA=''
     export DEBIAN_FRONTEND=noninteractive
-elif which sudo &>/dev/null; then
+elif which sudo >/dev/null 2>&1 ; then
     SUDO='sudo DEBIAN_FRONTEND=noninteractive'
     SUDOEULA='sudo ACCEPT_EULA=Y'
 
@@ -37,12 +37,12 @@ $SUDO apt-get install -y ca-certificates
 $SUDO apt-get install -y gnupg
 
 # Common build requirements
-$SUDO apt-get install -y libssl-dev libreadline-dev libsqlite3-dev libbz2-dev \
-  zlib1g-dev
+$SUDO apt-get install -y build-essential \
+  libssl-dev libreadline-dev libsqlite3-dev libbz2-dev zlib1g-dev
 
 # Utils
-$SUDO apt-get install -y build-essential coreutils dnsutils file \
-  findutils git htop lsb-release procps traceroute unzip wget whois
+$SUDO apt-get install -y bash coreutils dnsutils file findutils \
+  git htop lsb-release procps traceroute unzip wget whois
 
 # Locales (required on Debian)
 $SUDO apt-get install -y locales

--- a/bin/install_apps_snap
+++ b/bin/install_apps_snap
@@ -2,7 +2,7 @@
 
 trap "echo -e '\nCaught ^C from user - exiting now' ; exit 130" SIGINT
 
-if [ "$EUID" = "0" ]; then
+if [ "$(id -u)" = 0 ]; then
     SUDO=''
 elif which sudo &>/dev/null; then
     SUDO='sudo'

--- a/bin/install_apps_yum
+++ b/bin/install_apps_yum
@@ -1,10 +1,10 @@
-#!/bin/bash
+#!/bin/sh
 
-trap "echo -e '\nCaught ^C from user - exiting now' ; exit 130" SIGINT
+trap "echo -e '\nCaught ^C from user - exiting now' ; exit 130" INT
 
-if [ "$EUID" = "0" ]; then
+if [ "$(id -u)" = 0 ]; then
     SUDO=''
-elif which sudo &>/dev/null; then
+elif which sudo >/dev/null 2>&1 ; then
     SUDO='sudo'
 
     # Ask sudo password upfront
@@ -34,12 +34,12 @@ $SUDO yum install -y ca-certificates
 $SUDO yum install -y gnupg
 
 # Common build requirements
-$SUDO yum install -y openssl-devel readline-devel sqlite-devel bzip2-devel \
-  zlib-devel
+$SUDO yum install -y gcc gcc-c++ make \
+  openssl-devel readline-devel sqlite-devel bzip2-devel zlib-devel
 
 # Utils
-$SUDO yum install -y gcc gcc-c++ make coreutils bind-utils file \
-  findutils git htop redhat-lsb-core procps traceroute unzip wget whois
+$SUDO yum install -y bash coreutils bind-utils file findutils \
+  git htop redhat-lsb-core procps traceroute unzip wget whois
 
 # pbcopy/pbpaste like experience
 $SUDO yum install -y xsel

--- a/bin/install_bash
+++ b/bin/install_bash
@@ -21,7 +21,8 @@ if ! which brew &>/dev/null ; then
 fi
 
 brew install bash
-brew install bash-completion || (brew unlink util-linux && brew install bash-completion)
+brew install bash-completion || \
+  (brew unlink util-linux && brew install bash-completion)
 
 ### Set bash as the default shell ##############################################
 

--- a/bin/install_fonts
+++ b/bin/install_fonts
@@ -3,10 +3,10 @@
 trap "echo -e '\nCaught ^C from user - exiting now' ; exit 130" SIGINT
 
 this_path=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+fonts_dir="$this_path/../ui/fonts"
 
 ### Install fonts ##############################################################
 
-fonts_dir="$this_path/../ui/fonts"
 find_command="find \"$fonts_dir\" \( -name '*.[o,t]tf' -or -name '*.pcf.gz' \) \
   -type f -print0"
 

--- a/bootstrap
+++ b/bootstrap
@@ -8,6 +8,6 @@ this_path=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 
 "$this_path/symlink_dotfiles" -f
 "$this_path/install_apps"
-"$this_path/setup_vscode" -f
+"$this_path/setup_vscode"
 
 echo -e "\n✅ bootstrap done."

--- a/bootstrap
+++ b/bootstrap
@@ -1,13 +1,13 @@
-#!/bin/bash
+#!/bin/sh
 
 # shellcheck disable=SC1091   # disable not finding scripts as input
 
-trap "echo -e '\nCaught ^C from user - exiting now' ; exit 130" SIGINT
+trap "echo -e '\nCaught ^C from user - exiting now' ; exit 130" INT
 
-this_path=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+this_path=$(cd "$(dirname "$0")" && pwd)
 
 "$this_path/symlink_dotfiles" -f
 "$this_path/install_apps"
 "$this_path/setup_vscode"
 
-echo -e "\n✅ bootstrap done."
+printf "\n✅ bootstrap done."

--- a/bootstrap
+++ b/bootstrap
@@ -4,7 +4,7 @@
 
 trap "echo -e '\nCaught ^C from user - exiting now' ; exit 130" INT
 
-this_path=$(cd "$(dirname "$0")" && pwd)
+this_path="$(cd "$(dirname "$0")" && pwd)"
 
 "$this_path/symlink_dotfiles" -f
 "$this_path/install_apps"

--- a/dotfiles/.aliases
+++ b/dotfiles/.aliases
@@ -244,12 +244,6 @@ genpass() {
     fold -w $1 | head -n1 | pbcopy
 }
 
-# https://github.com/kdabir/has
-has() {
-  curl -sL https://raw.githubusercontent.com/kdabir/has/master/has | \
-    bash -s "$@"
-}
-
 # Show process listening on given port
 whatlistens() {
   lsof -P -i :"$1" | column -t

--- a/dotfiles/.bashrc
+++ b/dotfiles/.bashrc
@@ -63,9 +63,9 @@ else
   PS1="$txtblu\u@\h$txtrst:$txtcyn\w$txtrst\$ "
 fi
 
-#if which starship &>/dev/null ; then
-#  eval "$(starship init bash)"
-#fi
+if which starship &>/dev/null ; then
+  eval "$(starship init bash)"
+fi
 
 ### Additional bash completions ################################################
 

--- a/etc/lima/rancher.yaml
+++ b/etc/lima/rancher.yaml
@@ -34,11 +34,11 @@ provision:
 - mode: system
   script: |
     #!/bin/sh
-    curl -sfL https://get.k3s.io | sh -
-#- mode: user
-#  script: |
-#    #!/bin/bash
-#    NO_FORMULAE=true bash -c "$(curl -sS https://raw.githubusercontent.com/raas-dev/configent/main/install.sh)"
+    curl -fsSL https://get.k3s.io | sh
+- mode: user
+  script: |
+    #!/bin/bash
+    curl -fsSL https://raw.githubusercontent.com/raas-dev/configent/main/install.sh | NO_FORMULAE=true sh
 
 probes:
 - script: |

--- a/etc/lima/rancher.yaml
+++ b/etc/lima/rancher.yaml
@@ -38,7 +38,7 @@ provision:
 - mode: user
   script: |
     #!/bin/sh
-    curl -fsSL https://raw.githubusercontent.com/raas-dev/configent/v110/install.sh | NO_FORMULAE=true sh
+    curl -fsSL https://raw.githubusercontent.com/raas-dev/configent/main/install.sh | NO_FORMULAE=true sh
 
 probes:
 - script: |

--- a/etc/lima/rancher.yaml
+++ b/etc/lima/rancher.yaml
@@ -37,8 +37,8 @@ provision:
     curl -fsSL https://get.k3s.io | sh
 - mode: user
   script: |
-    #!/bin/bash
-    curl -fsSL https://raw.githubusercontent.com/raas-dev/configent/main/install.sh | NO_FORMULAE=true sh
+    #!/bin/sh
+    curl -fsSL https://raw.githubusercontent.com/raas-dev/configent/v110/install.sh | NO_FORMULAE=true sh
 
 probes:
 - script: |

--- a/etc/lima/ubuntu.yaml
+++ b/etc/lima/ubuntu.yaml
@@ -26,7 +26,7 @@ provision:
   - mode: user
     script: |
       #!/bin/bash
-      curl -fsSL https://raw.githubusercontent.com/raas-dev/configent/main/install.sh | sh
+      curl -fsSL https://raw.githubusercontent.com/raas-dev/configent/v110/install.sh | sh
 
 probes:
   - script: |

--- a/etc/lima/ubuntu.yaml
+++ b/etc/lima/ubuntu.yaml
@@ -23,10 +23,20 @@ provision:
     script: |
       #!/bin/sh
       sed -i 's/host.lima.internal.*/host.lima.internal host.docker.internal/' /etc/hosts
-#  - mode: user
-#    script: |
-#      #!/bin/bash
-#      curl -sS https://raw.githubusercontent.com/raas-dev/configent/main/install.sh | bash
+  - mode: user
+    script: |
+      #!/bin/bash
+      curl -fsSL https://raw.githubusercontent.com/raas-dev/configent/main/install.sh | sh
+
+probes:
+  - script: |
+      #!/bin/bash
+      set -eux -o pipefail
+      if ! timeout 30s bash -c "until pgrep rootlesskit; do sleep 3; done"; then
+        echo >&2 "rootlesskit (used by rootless docker) is not running"
+        exit 1
+      fi
+    hint: See "/var/log/cloud-init-output.log". in the guest
 
 portForwards:
   - guestSocket: "/run/user/{{.UID}}/docker.sock"

--- a/etc/lima/ubuntu.yaml
+++ b/etc/lima/ubuntu.yaml
@@ -26,7 +26,7 @@ provision:
   - mode: user
     script: |
       #!/bin/bash
-      curl -fsSL https://raw.githubusercontent.com/raas-dev/configent/v110/install.sh | sh
+      curl -fsSL https://raw.githubusercontent.com/raas-dev/configent/main/install.sh | sh
 
 probes:
   - script: |

--- a/install.sh
+++ b/install.sh
@@ -9,7 +9,6 @@
 
 ### constants  #################################################################
 
-SCRIPT_PATH=$(dirname "$0")
 GIT_REPO_URL="https://github.com/raas-dev/configent"
 TARGET_PATH="$HOME/configent"
 
@@ -71,13 +70,12 @@ fi
 
 if [ -t 0 ]; then
   # if in terminal/stdin present (script run by ./install.sh)
+  full_path=$(cd "$(dirname "$0")" && pwd)
   printf "\nChecking if inside the git working copy and ought to pull."
-  if [ -d "$SCRIPT_PATH/.git" ]; then
-    full_path=$(cd "$(dirname "$0")" && pwd)
+  if [ -d "$full_path/.git" ]; then
     printf "\nInside git working copy %s, pulling.\n" "$full_path"
-    git -C "$SCRIPT_PATH" pull --rebase
-    cd "$SCRIPT_PATH" && \
-      . "$SCRIPT_PATH/bootstrap" # 2> >(tee install_error.log >&2)
+    git -C "$full_path" pull --rebase
+    . "$full_path/bootstrap" # 2> >(tee install_error.log >&2)
   fi
 else
   # if not in terminal (script run by curl/wget/cat)
@@ -88,6 +86,5 @@ else
     printf "\nGit working copy found at %s, pulling." "$TARGET_PATH"
     git -C "$TARGET_PATH" pull --rebase
   fi
-  cd "$TARGET_PATH" && \
-    . "$TARGET_PATH/bootstrap" # 2> >(tee install_error.log >&2)
+  . "$TARGET_PATH/bootstrap" # 2> >(tee install_error.log >&2)
 fi

--- a/install.sh
+++ b/install.sh
@@ -76,7 +76,8 @@ if [ -t 0 ]; then
     full_path=$(cd "$(dirname "$0")" && pwd)
     printf "\nInside git working copy %s, pulling.\n" "$full_path"
     git -C "$SCRIPT_PATH" pull --rebase
-    . "$SCRIPT_PATH/bootstrap" # 2> >(tee install_error.log >&2)
+    cd "$SCRIPT_PATH" && \
+      . "$SCRIPT_PATH/bootstrap" # 2> >(tee install_error.log >&2)
   fi
 else
   # if not in terminal (script run by curl/wget/cat)
@@ -87,6 +88,6 @@ else
     printf "\nGit working copy found at %s, pulling." "$TARGET_PATH"
     git -C "$TARGET_PATH" pull --rebase
   fi
-
-  . "$TARGET_PATH/bootstrap" # 2> >(tee install_error.log >&2)
+  cd "$TARGET_PATH" && \
+    . "$TARGET_PATH/bootstrap" # 2> >(tee install_error.log >&2)
 fi

--- a/install.sh
+++ b/install.sh
@@ -86,5 +86,6 @@ else
     printf "\nGit working copy found at %s, pulling." "$TARGET_PATH"
     git -C "$TARGET_PATH" pull --rebase
   fi
-  . "$TARGET_PATH/bootstrap" # 2> >(tee install_error.log >&2)
+  cd "$TARGET_PATH" && \
+    . "$TARGET_PATH/bootstrap" # 2> >(tee install_error.log >&2)
 fi

--- a/install.sh
+++ b/install.sh
@@ -86,6 +86,5 @@ else
     printf "\nGit working copy found at %s, pulling." "$TARGET_PATH"
     git -C "$TARGET_PATH" pull --rebase
   fi
-  cd "$TARGET_PATH" && \
-    . "$TARGET_PATH/bootstrap" # 2> >(tee install_error.log >&2)
+  . "$TARGET_PATH/bootstrap" # 2> >(tee install_error.log >&2)
 fi

--- a/install_apps
+++ b/install_apps
@@ -1,35 +1,35 @@
-#!/bin/bash
+#!/bin/sh
 
-this_path=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+this_path=$(cd "$(dirname "$0")" && pwd)
 bin_path="$this_path/bin"
 
-trap "echo -e '\nCaught ^C from user - exiting now' ; exit 130" SIGINT
+trap "echo -e '\nCaught ^C from user - exiting now' ; exit 130" INT
 
-if [[ "$OSTYPE" = darwin* ]]; then
-  if [[ -z "$NO_CASKS" ]] ; then
+if [ "$(uname -s)" = 'Darwin' ]; then
+  if [ -z "$NO_CASKS" ] ; then
     "$bin_path/install_apps_cask"
   else
     echo "NO_CASKS was specified and on macOS, won't install casks."
   fi
-elif [[ "$OSTYPE" = linux-gnu* ]] ; then
-  if which apt-get &>/dev/null ; then
+elif [ "$(uname -s)" = 'Linux' ] ; then
+  if which apt-get >/dev/null 2>&1  ; then
     "$bin_path/install_apps_apt"
-  elif which yum &>/dev/null ; then
+  elif which yum >/dev/null 2>&1  ; then
     "$bin_path/install_apps_yum"
   fi
-  if [[ -z "$NO_SNAPS" ]] ; then
+  if [ -z "$NO_SNAPS" ] ; then
     "$bin_path/install_apps_snap"
   else
     echo "NO_SNAPS was specified and on Linux, won't install snaps."
   fi
 else
-  echo -e "\nError: Only macOS and APT and YUM Linux distros are supported."
+  printf "\nError: Only macOS and APT and YUM Linux distros are supported."
   exit 1
 fi
 
 "$bin_path/install_fonts"
 
-if [[ -z "$NO_FORMULAE" ]] ; then
+if [ -z "$NO_FORMULAE" ] ; then
   NO_PROMPT_DEFAULT_SHELL=true "$bin_path/install_bash"
   "$bin_path/install_tmux"
   "$bin_path/install_utils"

--- a/setup_vscode
+++ b/setup_vscode
@@ -8,20 +8,6 @@ this_path=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 
 vscode_settings_path="$this_path/vscode"
 
-### Parse arguments ############################################################
-
-args=''
-while getopts 'f' arg ; do
-  case "$arg" in
-    f)
-      args='f'
-      ;;
-    *)
-      exit 1
-      ;;
-  esac
-done
-
 ### Symlink Visual Studio Code configuration ###################################
 
 if [[ "$OSTYPE" = darwin* ]]; then
@@ -30,9 +16,9 @@ else
   user_path="$HOME/.config/Code/User"
 fi
 
-rm -r"$args" "${user_path}-old"
+rm -rf "${user_path}-old"
 mv "$user_path" "${user_path}-old"
-ln -snvi"$args" "$vscode_settings_path" "$user_path"
+ln -snvi "$vscode_settings_path" "$user_path"
 
 ### Install VSCode extensions ##################################################
 

--- a/setup_vscode
+++ b/setup_vscode
@@ -1,16 +1,12 @@
-#!/bin/bash
+#!/bin/sh
 
-trap "echo -e '\nCaught ^C from user - exiting now' ; exit 130" SIGINT
+trap "echo -e '\nCaught ^C from user - exiting now' ; exit 130" INT
 
-this_path=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
-
-### Configuration ##############################################################
-
-vscode_settings_path="$this_path/vscode"
+this_path=$(cd "$(dirname "$0")" && pwd)
 
 ### Symlink Visual Studio Code configuration ###################################
 
-if [[ "$OSTYPE" = darwin* ]]; then
+if [ "$(name -s)" = "Darwin" ]]; then
   user_path="$HOME/Library/Application Support/Code/User"
 else
   user_path="$HOME/.config/Code/User"
@@ -18,11 +14,11 @@ fi
 
 rm -rfv "${user_path}-old"
 mv -v "$user_path" "${user_path}-old"
-ln -snvi "$vscode_settings_path" "$user_path"
+ln -snvi "$this_path/vscode" "$user_path"
 
 ### Install VSCode extensions ##################################################
 
-if which code &>/dev/null ; then
+if which code >/dev/null 2>&1 ; then
   # code --list-extensions | xargs -L 1 echo "code --force --install-extension"
   code --force --install-extension Arjun.swagger-viewer
   code --force --install-extension bencoleman.armview

--- a/setup_vscode
+++ b/setup_vscode
@@ -10,11 +10,11 @@ vscode_settings_path="$this_path/vscode"
 
 ### Parse arguments ############################################################
 
-ln_args=''
+args=''
 while getopts 'f' arg ; do
   case "$arg" in
     f)
-      ln_args='f'
+      args='f'
       ;;
     *)
       exit 1
@@ -30,11 +30,9 @@ else
   user_path="$HOME/.config/Code/User"
 fi
 
-mkdir -p "$user_path"
-if [[ ! -L "$user_path" ]] ; then
-  mv -i "$user_path" "${user_path}-old"
-  ln -snvi"$ln_args" "$vscode_settings_path" "$user_path"
-fi
+rm -r"$args" "${user_path}-old"
+mv "$user_path" "${user_path}-old"
+ln -snvi"$args" "$vscode_settings_path" "$user_path"
 
 ### Install VSCode extensions ##################################################
 

--- a/setup_vscode
+++ b/setup_vscode
@@ -16,8 +16,8 @@ else
   user_path="$HOME/.config/Code/User"
 fi
 
-rm -rf "${user_path}-old"
-mv "$user_path" "${user_path}-old"
+rm -rfv "${user_path}-old"
+mv -v "$user_path" "${user_path}-old"
 ln -snvi "$vscode_settings_path" "$user_path"
 
 ### Install VSCode extensions ##################################################

--- a/symlink_dotfiles
+++ b/symlink_dotfiles
@@ -31,16 +31,16 @@ done
 ### Symlink bin ################################################################
 
 local_bin_path="$HOME/local/bin"
-rm -r"$args" "${local_bin_path}-old"
+rm -rf "${local_bin_path}-old"
 mv "$local_bin_path" "${local_bin_path}-old"
-ln -snvi"$args" "$this_path/bin" "$local_bin_path"
+ln -snvi "$this_path/bin" "$local_bin_path"
 
 ### Symlink etc ################################################################
 
 local_etc_path="$HOME/local/etc"
-rm -r"$args" "${local_etc_path}-old"
+rm -rf "${local_etc_path}-old"
 mv "$local_etc_path" "${local_etc_path}-old"
-ln -snvi"$args" "$this_path/etc" "$local_etc_path"
+ln -snvi "$this_path/etc" "$local_etc_path"
 
 ### Symlink dotfiles ###########################################################
 
@@ -79,8 +79,8 @@ fi
 #if [[ "$OSTYPE" = linux-gnu* ]] ; then
 #  xfce_configs_path="$HOME/.config/xfce4"
 #  if [ -d "$xfce_configs_path" ] ; then
-      #rm -r"$args" "${xfce_configs_path}-old"
+#     rm -rf "${xfce_configs_path}-old"
 #     mv "$xfce_configs_path" "${xfce_configs_path}-old"
-#     ln -snvi"$args" "$dotfiles_path/xfce4" "$xfce_configs_path"
+#     ln -snvi "$dotfiles_path/xfce4" "$xfce_configs_path"
 #  fi
 #fi

--- a/symlink_dotfiles
+++ b/symlink_dotfiles
@@ -1,18 +1,10 @@
-#!/bin/bash
+#!/bin/sh
 
 set -e
 set -u
 
-this_path=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
-
-### Configuration ##############################################################
-
+this_path=$(cd "$(dirname "$0")" && pwd)
 dotfiles_path="$this_path/dotfiles"
-
-# Do not symlink these paths. Paths are relative to $dotfiles_path.
-do_not_symlink=(
-  "xfce4"
-)
 
 ### Parse arguments ############################################################
 
@@ -44,20 +36,13 @@ ln -snvi "$this_path/etc" "$local_etc_path"
 
 ### Symlink dotfiles ###########################################################
 
-in_array() {
-  local e
-  for e in "${@:2}" ; do
-    [[ "$e" == "$1" ]] && return 0
-  done
-  return 1
-}
+files="$(find "$dotfiles_path" -type f -exec basename {} \;)"
 
-for source_file_name in $(ls -A $dotfiles_path) ; do
-  if (in_array "$source_file_name" "${do_not_symlink[@]}") ; then
-    echo "Ignoring: $source_file_name"
+for source_file_name in $files ; do
+  if [ "$source_file_name" = "xfce4" ]; then
+    printf "Ignoring %s\n" "$source_file_name"
   else
-    ln -snvi"$args" "$dotfiles_path/$source_file_name" \
-      "$HOME/$source_file_name"
+    ln -snvi"$args" "$dotfiles_path/$source_file_name" "$HOME/$source_file_name"
   fi
 done
 
@@ -69,14 +54,14 @@ ln -snvi"$args" "$HOME/local/etc/starship/config.toml" \
 
 ### Symlink htoprc for Linux distributions #####################################
 
-if [[ "$OSTYPE" = linux-gnu* ]] ; then
+if [ "$(uname -s)" = 'Linux' ] ; then
   mkdir -p "$HOME/.config/htop"
   ln -snvi"$args" "$dotfiles_path/.htoprc" "$HOME/.config/htop/htoprc"
 fi
 
 ### Symlink XFCE for Linux distributions #######################################
 
-#if [[ "$OSTYPE" = linux-gnu* ]] ; then
+#if [ "$(uname -s)" = 'Linux' ]; then
 #  xfce_configs_path="$HOME/.config/xfce4"
 #  if [ -d "$xfce_configs_path" ] ; then
 #     rm -rfv "${xfce_configs_path}-old"

--- a/symlink_dotfiles
+++ b/symlink_dotfiles
@@ -16,11 +16,11 @@ do_not_symlink=(
 
 ### Parse arguments ############################################################
 
-ln_args=''
+args=''
 while getopts 'f' arg ; do
   case "$arg" in
     f)
-      ln_args='f'
+      args='f'
       ;;
     *)
       exit 1
@@ -31,20 +31,16 @@ done
 ### Symlink bin ################################################################
 
 local_bin_path="$HOME/local/bin"
-mkdir -p "$local_bin_path"
-if [[ ! -L "$local_bin_path" ]] ; then
-  mv -i "$local_bin_path" "${local_bin_path}-old"
-  ln -snvi"$ln_args" "$this_path/bin" "$local_bin_path"
-fi
+rm -r"$args" "${local_bin_path}-old"
+mv "$local_bin_path" "${local_bin_path}-old"
+ln -snvi"$args" "$this_path/bin" "$local_bin_path"
 
 ### Symlink etc ################################################################
 
 local_etc_path="$HOME/local/etc"
-mkdir -p "$local_etc_path"
-if [[ ! -L "$local_etc_path" ]] ; then
-  mv -i "$local_etc_path" "${local_etc_path}-old"
-  ln -snvi"$ln_args" "$this_path/etc" "$local_etc_path"
-fi
+rm -r"$args" "${local_etc_path}-old"
+mv "$local_etc_path" "${local_etc_path}-old"
+ln -snvi"$args" "$this_path/etc" "$local_etc_path"
 
 ### Symlink dotfiles ###########################################################
 
@@ -60,7 +56,7 @@ for source_file_name in $(ls -A $dotfiles_path) ; do
   if (in_array "$source_file_name" "${do_not_symlink[@]}") ; then
     echo "Ignoring: $source_file_name"
   else
-    ln -snvi"$ln_args" "$dotfiles_path/$source_file_name" \
+    ln -snvi"$args" "$dotfiles_path/$source_file_name" \
       "$HOME/$source_file_name"
   fi
 done
@@ -68,14 +64,14 @@ done
 ### Symlink Starship config ####################################################
 
 mkdir -p "$HOME/.config"
-ln -svi"$ln_args" "$HOME/local/etc/starship/config.toml" \
+ln -snvi"$args" "$HOME/local/etc/starship/config.toml" \
   "$HOME/.config/starship.toml"
 
 ### Symlink htoprc for Linux distributions #####################################
 
 if [[ "$OSTYPE" = linux-gnu* ]] ; then
   mkdir -p "$HOME/.config/htop"
-  ln -snvi"$ln_args" "$dotfiles_path/.htoprc" "$HOME/.config/htop/htoprc"
+  ln -snvi"$args" "$dotfiles_path/.htoprc" "$HOME/.config/htop/htoprc"
 fi
 
 ### Symlink XFCE for Linux distributions #######################################
@@ -83,9 +79,8 @@ fi
 #if [[ "$OSTYPE" = linux-gnu* ]] ; then
 #  xfce_configs_path="$HOME/.config/xfce4"
 #  if [ -d "$xfce_configs_path" ] ; then
-#    if [[ ! -L "$xfce_configs_path" ]] ; then
-#      mv -i "$xfce_configs_path" "${xfce_configs_path}-old"
-#      ln -snvi"$ln_args" "$dotfiles_path/xfce4" "$xfce_configs_path"
-#    fi
+      #rm -r"$args" "${xfce_configs_path}-old"
+#     mv "$xfce_configs_path" "${xfce_configs_path}-old"
+#     ln -snvi"$args" "$dotfiles_path/xfce4" "$xfce_configs_path"
 #  fi
 #fi

--- a/symlink_dotfiles
+++ b/symlink_dotfiles
@@ -31,15 +31,15 @@ done
 ### Symlink bin ################################################################
 
 local_bin_path="$HOME/local/bin"
-rm -rf "${local_bin_path}-old"
-mv "$local_bin_path" "${local_bin_path}-old"
+rm -rfv "${local_bin_path}-old"
+mv -v "$local_bin_path" "${local_bin_path}-old"
 ln -snvi "$this_path/bin" "$local_bin_path"
 
 ### Symlink etc ################################################################
 
 local_etc_path="$HOME/local/etc"
-rm -rf "${local_etc_path}-old"
-mv "$local_etc_path" "${local_etc_path}-old"
+rm -rfv "${local_etc_path}-old"
+mv -v "$local_etc_path" "${local_etc_path}-old"
 ln -snvi "$this_path/etc" "$local_etc_path"
 
 ### Symlink dotfiles ###########################################################
@@ -79,8 +79,8 @@ fi
 #if [[ "$OSTYPE" = linux-gnu* ]] ; then
 #  xfce_configs_path="$HOME/.config/xfce4"
 #  if [ -d "$xfce_configs_path" ] ; then
-#     rm -rf "${xfce_configs_path}-old"
-#     mv "$xfce_configs_path" "${xfce_configs_path}-old"
+#     rm -rfv "${xfce_configs_path}-old"
+#     mv -v "$xfce_configs_path" "${xfce_configs_path}-old"
 #     ln -snvi "$dotfiles_path/xfce4" "$xfce_configs_path"
 #  fi
 #fi

--- a/vscode/settings.json
+++ b/vscode/settings.json
@@ -132,7 +132,7 @@
     },
     "workbench.editor.untitled.hint": "hidden",
     "git.confirmSync": false,
-    "window.zoomLevel": 1,
     "bracketPairColorizer.depreciation-notice": false,
-    "security.workspace.trust.enabled": false
+    "security.workspace.trust.enabled": false,
+    "window.zoomLevel": 1
 }


### PR DESCRIPTION
- dotfiles/.aliases: remove alias `has` [BWIC]
- symlink_dotfiles
  - override `~/local/bin` and `~/local/etc` even if no `-f` given
  - improve verbosity
- setup_vscode:
  - override `~/Code` even if no `-f` given
  - remove support for `-f`
  - improve verbosity
- unify curl arguments
- add support for bootstrap with sh
- add bash installation to apt/yum
- add lima-vm user provisioning (run install.sh)
- add lima-vm user provisioning probes (ensure rootlessd running)